### PR TITLE
Fix dockerfile import instruction error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,18 +59,7 @@ USER appuser
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 \
-    CMD python -c "
-import requests
-import sys
-try:
-    response = requests.get('http://localhost:8000/health', timeout=10)
-    if response.status_code == 200:
-        sys.exit(0)
-    else:
-        sys.exit(1)
-except:
-    sys.exit(1)
-" || exit 1
+    CMD python -c "import urllib.request; import sys; urllib.request.urlopen('http://localhost:8000/health', timeout=10); sys.exit(0)" || exit 1
 
 # Expose port
 EXPOSE 8000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 
 services:
   # Main application
@@ -36,7 +35,7 @@ services:
     networks:
       - user_management_network
     healthcheck:
-      test: ["CMD", "python", "-c", "import requests; requests.get('http://localhost:8000/health', timeout=10)"]
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health', timeout=10)"]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
Fix Docker build errors by correcting Dockerfile HEALTHCHECK syntax and removing the obsolete `version` attribute from `docker-compose.yml`.

The Dockerfile's multi-line Python code within the `HEALTHCHECK` instruction was misinterpreted as Docker commands, causing an "unknown instruction: import" error. This PR resolves the syntax, removes the deprecated `version` attribute, and standardizes the healthcheck to use `urllib.request`.

---
<a href="https://cursor.com/background-agent?bcId=bc-78d8586f-ac9e-41e7-ac51-6d46338aea2b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-78d8586f-ac9e-41e7-ac51-6d46338aea2b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

